### PR TITLE
Add etcdctl script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,16 @@ $ docker run --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provis
 
 ## etcd
 
-First, download `etcdctl` ([see etcd client](https://github.com/etcd-io/etcd/releases/tag/v3.4.20)).
-
 ```bash
+# run the datastore
 $ /opt/ccf/bin/sandbox.sh -p build/libccf_kvs.virtual.so --http2
 ...
 
 # In another terminal
-$ etcdctl --endpoints=127.0.0.1:8000 --insecure-transport=false --insecure-skip-tls-verify=true put key value
+$ ./etcdctl.sh put key value
 OK
 
-$ etcdctl --endpoints=127.0.0.1:8000 --insecure-transport=false --insecure-skip-tls-verify=true get key
+$ ./etcdctl.sh get key
 key
 value
 ```

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ $ docker run --device /dev/sgx_enclave:/dev/sgx_enclave --device /dev/sgx_provis
 ## etcd
 
 ```bash
-# run the datastore
+# run the datastore from the project root
 $ /opt/ccf/bin/sandbox.sh -p build/libccf_kvs.virtual.so --http2
 ...
 
-# In another terminal
+# In another terminal, from the project root
 $ ./etcdctl.sh put key value
 OK
 

--- a/etcdctl.sh
+++ b/etcdctl.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+set -e
+
+bindir=bin
+
+install_etcdctl() {
+    ETCD_VER="v3.5.4"
+
+    GITHUB_URL=https://github.com/etcd-io/etcd/releases/download
+    DOWNLOAD_URL=${GITHUB_URL}
+
+    rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
+    rm -rf /tmp/etcd-download-test && mkdir -p /tmp/etcd-download-test
+
+    curl -L ${DOWNLOAD_URL}/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
+    tar xzvf /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz -C /tmp/etcd-download-test --strip-components=1
+    rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz
+
+    mkdir -p $bindir
+    mv /tmp/etcd-download-test/etcdctl $bindir/etcdctl
+}
+
+if [ ! -f "$bindir/etcdctl" ]; then
+    install_etcdctl
+fi
+
+cmd="$bindir/etcdctl --endpoints=https://127.0.0.1:8000 --insecure-transport=false --insecure-skip-tls-verify=true $@"
+echo $cmd
+$cmd

--- a/etcdctl.sh
+++ b/etcdctl.sh
@@ -25,6 +25,8 @@ if [ ! -f "$bindir/etcdctl" ]; then
     install_etcdctl
 fi
 
-cmd="$bindir/etcdctl --endpoints=https://127.0.0.1:8000 --insecure-transport=false --insecure-skip-tls-verify=true $@"
+workspace_common=workspace/sandbox_common
+
+cmd="$bindir/etcdctl --endpoints=https://127.0.0.1:8000 --cacert=$workspace_common/service_cert.pem --cert=$workspace_common/user0_cert.pem --key=$workspace_common/user0_privk.pem $@"
 echo $cmd
 $cmd


### PR DESCRIPTION
This adds a convenience script to avoid having to right incantation. It also downloads the binary if needed.

This also fixes the run command in the `Makefile` which was missing the `--http2` flag.