### PR TITLE
Implement range query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ add_subdirectory(3rdparty)
 add_subdirectory(proto)
 
 add_ccf_app(ccf_kvs SRCS src/app/app.cpp
-  INCLUDE_DIRS "${CMAKE_BINARY_DIR}/proto"
+  INCLUDE_DIRS "${CMAKE_BINARY_DIR}/proto" "/opt/ccf/include/ccf/_private"
   LINK_LIBS_ENCLAVE etcd.enclave status.enclave protobuf.enclave
   LINK_LIBS_VIRTUAL etcd.virtual status.virtual protobuf.virtual)
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build-virtual:
 
 .PHONY: run-virtual
 run-virtual: build-virtual
-	$(CCF_PREFIX)/bin/sandbox.sh -p $(BUILD)/libccf_kvs.virtual.so
+	$(CCF_PREFIX)/bin/sandbox.sh -p $(BUILD)/libccf_kvs.virtual.so --http2
 
 .PHONY: clean
 clean:

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -64,7 +64,7 @@ namespace app
         auto records_handle = ctx.tx.template ro<Map>(RECORDS);
         auto key = payload.key();
         auto range_end = payload.range_end();
-        if (range_end.size() == 0) {
+        if (range_end.empty()) {
           // empty range end so just query for a single key
           auto value_option = records_handle->get(ccf::ByteVector(key.begin(), key.end()));
           if (!value_option.has_value())

--- a/src/app/grpc.h
+++ b/src/app/grpc.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 #pragma once
 
-#include "ccf/_private/ds/serialized.h" // TODO: Private header
+#include "ds/serialized.h" // TODO: Private header
 #include "grpc_status.h"
 
 #include <arpa/inet.h>


### PR DESCRIPTION
Fixes #4 

- The map type used is now an untyped map so we can access the `range` api
- The `range_end` key is now checked for its size and if non-empty we use our new iteration to get multiple return values
- Added the `_private` includes to the cmake build and updated the grpc header to work with this too
- Fixed the run target in the Makefile to ensure it uses http2