### PR TITLE
Add Value type and map manipulation methods that use it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_ccf_app(
   ccf_kvs
   SRCS
   src/app/app.cpp
+  src/app/kvstore.cpp
   INCLUDE_DIRS
   "${CMAKE_BINARY_DIR}/proto"
   "/opt/ccf/include/ccf/_private"

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -395,10 +395,9 @@ namespace app
         // otherwise remove it and maybe plug the old value in to the
         // response.
 
-        auto old_option = records_map.get(key);
+        auto old_option = records_map.remove(key);
         if (old_option.has_value())
         {
-          records_map.remove(key);
           delete_range_response.set_deleted(1);
 
           if (payload.prev_kv())

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -166,8 +166,8 @@ namespace app
       }
 
       auto records_handle = ctx.tx.template ro<Map>(RECORDS);
-      auto key = payload.key();
-      auto range_end = payload.range_end();
+      auto& key = payload.key();
+      auto& range_end = payload.range_end();
       if (range_end.empty())
       {
         // empty range end so just query for a single key
@@ -194,9 +194,9 @@ namespace app
       else
       {
         // range end is non-empty so perform a range scan
-        auto start = payload.key();
+        auto& start = payload.key();
         auto start_bytes = ccf::ByteVector(start.begin(), start.end());
-        auto end = payload.range_end();
+        auto& end = payload.range_end();
         auto end_bytes = ccf::ByteVector(end.begin(), end.end());
         auto count = 0;
 
@@ -288,7 +288,7 @@ namespace app
       etcdserverpb::DeleteRangeResponse delete_range_response;
 
       auto records_handle = ctx.tx.template rw<Map>(RECORDS);
-      auto key = payload.key();
+      auto& key = payload.key();
 
       if (payload.range_end().empty())
       {
@@ -323,9 +323,9 @@ namespace app
 
         auto deleted = 0;
 
-        auto start = payload.key();
+        auto& start = payload.key();
         auto start_bytes = ccf::ByteVector(start.begin(), start.end());
-        auto end = payload.range_end();
+        auto& end = payload.range_end();
 
         // If range_end is '\0', the range is all keys greater than or equal
         // to the key argument.
@@ -458,7 +458,7 @@ namespace app
         value.version = old_val.version + 1;
       }
 
-      const nlohmann::json j = value;
+      const json j = value;
       auto value_bytes = j.dump();
       handle->put(
         ccf::ByteVector(key.begin(), key.end()),

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -414,11 +414,7 @@ namespace app
 
       auto version_opt = handle->get_version_of_previous_write(
         ccf::ByteVector(key.begin(), key.end()));
-      uint64_t revision = 0;
-      if (version_opt.has_value())
-      {
-        revision = version_opt.value();
-      }
+      uint64_t revision = version_opt.value_or(0);
 
       // if this was the first insert then we need to get the creation revision.
       if (v.create_revision == 0)
@@ -428,7 +424,7 @@ namespace app
 
       v.mod_revision = revision;
 
-      return std::make_optional(v);
+      return v;
     }
 
     static std::optional<Value> put_value(

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -64,15 +64,15 @@ namespace app
 
     /// @brief Constructs a KVStore
     /// @param ctx
-    KVStore(ccf::endpoints::EndpointContext& ctx)
+    KVStore(kv::Tx& tx)
     {
-      inner_map = ctx.tx.template rw<KVStore::MT>(RECORDS);
+      inner_map = tx.template rw<KVStore::MT>(RECORDS);
     }
     /// @brief Constructs a KVStore
     /// @param ctx
-    KVStore(ccf::endpoints::ReadOnlyEndpointContext& ctx)
+    KVStore(kv::ReadOnlyTx& tx)
     {
-      inner_map = ctx.tx.template ro<KVStore::MT>(RECORDS);
+      inner_map = tx.template ro<KVStore::MT>(RECORDS);
     }
 
     /// @brief get retrieves the value stored for the given key. It hydrates the
@@ -301,7 +301,7 @@ namespace app
             payload.max_create_revision()));
       }
 
-      auto records_map = KVStore(ctx);
+      auto records_map = KVStore(ctx.tx);
       auto& key = payload.key();
       auto& range_end = payload.range_end();
       if (range_end.empty())
@@ -391,7 +391,7 @@ namespace app
           fmt::format("ignore lease not yet supported"));
       }
 
-      auto records_map = KVStore(ctx);
+      auto records_map = KVStore(ctx.tx);
       records_map.put(payload.key(), Value(payload.value()));
       ctx.rpc_ctx->set_response_status(HTTP_STATUS_OK);
 
@@ -412,7 +412,7 @@ namespace app
         payload.prev_kv());
       etcdserverpb::DeleteRangeResponse delete_range_response;
 
-      auto records_map = KVStore(ctx);
+      auto records_map = KVStore(ctx.tx);
       auto& key = payload.key();
 
       if (payload.range_end().empty())

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -77,8 +77,7 @@ namespace app
       }
       auto val = VSerialiser::from_serialised(res.value());
 
-      auto& val_ref = val;
-      hydrate_value(key, val_ref);
+      hydrate_value(key, val);
 
       return val;
     }
@@ -90,8 +89,7 @@ namespace app
         [&](auto& key, auto& value) {
           auto k = KSerialiser::from_serialised(key);
           auto v = VSerialiser::from_serialised(value);
-          auto& v_ref = v;
-          hydrate_value(k, v_ref);
+          hydrate_value(k, v);
           fn(k, v);
         },
         KSerialiser::to_serialised(from),

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -31,19 +31,17 @@ namespace app
     // the version of this key, reset on delete and incremented every update.
     uint64_t version;
 
-    Value()
-    {
-      value = "";
-      create_revision = 0;
-      mod_revision = 0;
-      version = 1;
-    }
     Value(std::string v)
     {
       value = v;
       create_revision = 0;
       mod_revision = 0;
       version = 1;
+    }
+
+    Value()
+    {
+      Value("");
     }
   };
   DECLARE_JSON_TYPE(Value);

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -325,7 +325,7 @@ namespace app
 
         auto& start = payload.key();
         auto start_bytes = ccf::ByteVector(start.begin(), start.end());
-        auto& end = payload.range_end();
+        auto end = payload.range_end();
 
         // If range_end is '\0', the range is all keys greater than or equal
         // to the key argument.

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -64,6 +64,10 @@ namespace app
     {
       inner_map = ctx.tx.template rw<KVStore::MT>(RECORDS);
     }
+    KVStore(ccf::endpoints::ReadOnlyEndpointContext& ctx)
+    {
+      inner_map = ctx.tx.template ro<KVStore::MT>(RECORDS);
+    }
 
     std::optional<V> get(const K& key)
     {
@@ -173,7 +177,7 @@ namespace app
       const auto etcdserverpb = "etcdserverpb";
       const auto kv = "KV";
 
-      make_grpc<etcdserverpb::RangeRequest, etcdserverpb::RangeResponse>(
+      make_grpc_ro<etcdserverpb::RangeRequest, etcdserverpb::RangeResponse>(
         etcdserverpb, kv, "Range", this->range, ccf::no_auth_required)
         .install();
 
@@ -193,7 +197,7 @@ namespace app
     }
 
     static ccf::grpc::GrpcAdapterResponse<etcdserverpb::RangeResponse> range(
-      ccf::endpoints::EndpointContext& ctx,
+      ccf::endpoints::ReadOnlyEndpointContext& ctx,
       etcdserverpb::RangeRequest&& payload)
     {
       etcdserverpb::RangeResponse range_response;

--- a/src/app/kvstore.cpp
+++ b/src/app/kvstore.cpp
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "kvstore.h"
+
+#include "ccf/app_interface.h"
+#include "ccf/common_auth_policies.h"
+#include "ccf/http_query.h"
+#include "ccf/json_handler.h"
+#include "kv/untyped_map.h" // TODO(#22): private header
+
+#include <nlohmann/json.hpp>
+
+namespace app::store
+{
+  using json = nlohmann::json;
+
+  static constexpr auto RECORDS = "public:records";
+
+  Value::Value(std::string v)
+  {
+    value = v;
+    create_revision = 0;
+    mod_revision = 0;
+    version = 1;
+  }
+
+  Value::Value() = default;
+
+  DECLARE_JSON_TYPE(Value);
+  DECLARE_JSON_REQUIRED_FIELDS(Value, value, create_revision, version);
+
+  // using K = std::string;
+  // using V = Value;
+  // using KSerialiser = kv::serialisers::BlitSerialiser<K>;
+  // using VSerialiser = kv::serialisers::JsonSerialiser<V>;
+
+  // Use untyped map so we can access the range API.
+  // using MT = kv::untyped::Map;
+
+  /// @brief Constructs a KVStore
+  /// @param ctx
+  KVStore::KVStore(kv::Tx& tx)
+  {
+    inner_map = tx.template rw<KVStore::MT>(RECORDS);
+  }
+  /// @brief Constructs a KVStore
+  /// @param ctx
+  KVStore::KVStore(kv::ReadOnlyTx& tx)
+  {
+    inner_map = tx.template ro<KVStore::MT>(RECORDS);
+  }
+
+  /// @brief get retrieves the value stored for the given key. It hydrates the
+  /// value with up-to-date information as values may not store all
+  /// information about revisions.
+  /// @param key the key to get.
+  /// @return The value, if present.
+  std::optional<KVStore::V> KVStore::get(const KVStore::K& key)
+  {
+    // get the value out and deserialise it
+    auto res = inner_map->get(KSerialiser::to_serialised(key));
+    if (!res.has_value())
+    {
+      return std::nullopt;
+    }
+    auto val = VSerialiser::from_serialised(res.value());
+
+    hydrate_value(key, val);
+
+    return val;
+  }
+
+  void KVStore::range(
+    const std::function<void(KVStore::K&, KVStore::V&)>& fn,
+    const KVStore::K& from,
+    const KVStore::K& to)
+  {
+    inner_map->range(
+      [&](auto& key, auto& value) {
+        auto k = KVStore::KSerialiser::from_serialised(key);
+        auto v = KVStore::VSerialiser::from_serialised(value);
+        hydrate_value(k, v);
+        fn(k, v);
+      },
+      KVStore::KSerialiser::to_serialised(from),
+      KVStore::KSerialiser::to_serialised(to));
+  }
+
+  /// @brief Associate a value with a key in the store, replacing existing
+  /// entries for that key.
+  ///
+  /// When an entry doesn't exist already this simply writes the data in.
+  ///
+  /// When an entry does exist already this gets the old value, and uses the
+  /// data to build the new version and, if not set, a create revision.
+  /// @param key where to insert
+  /// @param value data to insert
+  /// @return the old value associated with the key, if present.
+  std::optional<KVStore::V> KVStore::put(KVStore::K key, KVStore::V value)
+  {
+    const auto old = this->get(key);
+    if (old.has_value())
+    {
+      const auto old_val = old.value();
+      if (old_val.create_revision == 0)
+      {
+        // first put after creation of this key so set the revision
+        auto version_opt = inner_map->get_version_of_previous_write(
+          KVStore::KSerialiser::to_serialised(key));
+        if (version_opt.has_value())
+        {
+          // can set the creation revision
+          value.create_revision = version_opt.value();
+        }
+      }
+      else
+      {
+        // otherwise just copy it to the new value so that we don't lose it
+        value.create_revision = old_val.create_revision;
+      }
+
+      value.version = old_val.version + 1;
+    }
+
+    inner_map->put(
+      KVStore::KSerialiser::to_serialised(key),
+      KVStore::VSerialiser::to_serialised(value));
+
+    return old;
+  }
+
+  /// @brief remove data associated with the key from the store.
+  /// @param key
+  /// @return the old value, if present in the store.
+  std::optional<KVStore::V> KVStore::remove(const KVStore::K& key)
+  {
+    auto k = KVStore::KSerialiser::to_serialised(key);
+    auto old = inner_map->get(k);
+    inner_map->remove(k);
+    if (old.has_value())
+    {
+      return KVStore::VSerialiser::from_serialised(old.value());
+    }
+    else
+    {
+      return std::nullopt;
+    }
+  }
+
+  void KVStore::hydrate_value(const K& key, V& value)
+  {
+    // the version of the write to this key is our revision
+    auto version_opt =
+      inner_map->get_version_of_previous_write(KSerialiser::to_serialised(key));
+    // if there is no version (somehow) then just default it
+    // this shouldn't be nullopt though.
+    uint64_t revision = version_opt.value_or(0);
+
+    // if this was the first insert then we need to set the creation revision.
+    if (value.create_revision == 0)
+    {
+      value.create_revision = revision;
+    }
+
+    // and always set the mod_revision
+    value.mod_revision = revision;
+  }
+}; // namespace app::store

--- a/src/app/kvstore.h
+++ b/src/app/kvstore.h
@@ -1,0 +1,66 @@
+#include "ccf/app_interface.h"
+#include "ccf/common_auth_policies.h"
+#include "ccf/http_query.h"
+#include "ccf/json_handler.h"
+#include "kv/untyped_map.h" // TODO(#22): private header
+
+namespace app::store
+{
+
+  struct Value
+  {
+    // the actual value that the client wants written.
+    std::string value;
+    // the revision that this entry was created (since the last delete).
+    uint64_t create_revision;
+    // the latest modification of this entry (0 in the serialised field).
+    uint64_t mod_revision;
+    // the version of this key, reset on delete and incremented every update.
+    uint64_t version;
+
+    Value(std::string v);
+    Value();
+  };
+
+  class KVStore
+  {
+  public:
+    using K = std::string;
+    using V = Value;
+    using KSerialiser = kv::serialisers::BlitSerialiser<K>;
+    using VSerialiser = kv::serialisers::JsonSerialiser<V>;
+    using MT = kv::untyped::Map;
+    KVStore(kv::Tx& tx);
+    KVStore(kv::ReadOnlyTx& tx);
+    /// @brief get retrieves the value stored for the given key. It hydrates the
+    /// value with up-to-date information as values may not store all
+    /// information about revisions.
+    /// @param key the key to get.
+    /// @return The value, if present.
+    std::optional<V> get(const K& key);
+
+    void range(
+      const std::function<void(K&, V&)>& fn, const K& from, const K& to);
+
+    /// @brief Associate a value with a key in the store, replacing existing
+    /// entries for that key.
+    ///
+    /// When an entry doesn't exist already this simply writes the data in.
+    ///
+    /// When an entry does exist already this gets the old value, and uses the
+    /// data to build the new version and, if not set, a create revision.
+    /// @param key where to insert
+    /// @param value data to insert
+    /// @return the old value associated with the key, if present.
+    std::optional<V> put(K key, V value);
+
+    /// @brief remove data associated with the key from the store.
+    /// @param key
+    /// @return the old value, if present in the store.
+    std::optional<V> remove(const K& key);
+
+  private:
+    MT::Handle* inner_map;
+    void hydrate_value(const K& key, V& value);
+  };
+};

--- a/src/app/kvstore.h
+++ b/src/app/kvstore.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #include "ccf/app_interface.h"
 #include "ccf/common_auth_policies.h"
 #include "ccf/http_query.h"

--- a/src/app/kvstore.h
+++ b/src/app/kvstore.h
@@ -6,7 +6,6 @@
 
 namespace app::store
 {
-
   struct Value
   {
     // the actual value that the client wants written.


### PR DESCRIPTION
This allows us to store fields with the value, like create revision.

The create revision can't be set inside the transaction that creates the value since we don't know the id, but the next time we access it we can fill it in, either just in the response to the user or in a new KV when overwriting it.