### PR TITLE
Make `records` KV table private

### DIFF
--- a/src/app/kvstore.cpp
+++ b/src/app/kvstore.cpp
@@ -15,7 +15,7 @@ namespace app::store
 {
   using json = nlohmann::json;
 
-  static constexpr auto RECORDS = "public:records";
+  static constexpr auto RECORDS = "records";
 
   Value::Value(std::string v)
   {


### PR DESCRIPTION
As discussed, let's make the records table private by default. We can review this at a later stage and add configuration for storing some keys in a public table.