### PR TITLE
Encode values as byte vectors in the store

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -152,7 +152,7 @@ namespace app
         auto* kv = range_response.add_kvs();
         kv->set_key(payload.key());
         auto value = value_option.value();
-        kv->set_value(value.value.decode());
+        kv->set_value(value.get_data());
         kv->set_create_revision(value.create_revision);
         kv->set_mod_revision(value.mod_revision);
         kv->set_version(value.version);
@@ -173,7 +173,7 @@ namespace app
             // add the kv to the response
             auto* kv = range_response.add_kvs();
             kv->set_key(key);
-            kv->set_value(value.value.decode());
+            kv->set_value(value.get_data());
             kv->set_create_revision(value.create_revision);
             kv->set_mod_revision(value.mod_revision);
             kv->set_version(value.version);
@@ -265,7 +265,7 @@ namespace app
             auto* prev_kv = delete_range_response.add_prev_kvs();
             prev_kv->set_key(payload.key());
             auto old_value = old_option.value();
-            prev_kv->set_value(old_value.value.decode());
+            prev_kv->set_value(old_value.get_data());
             prev_kv->set_create_revision(old_value.create_revision);
             prev_kv->set_mod_revision(old_value.mod_revision);
             prev_kv->set_version(old_value.version);
@@ -308,7 +308,7 @@ namespace app
               auto* prev_kv = delete_range_response.add_prev_kvs();
 
               prev_kv->set_key(key);
-              prev_kv->set_value(old.value.decode());
+              prev_kv->set_value(old.get_data());
               prev_kv->set_create_revision(old.create_revision);
               prev_kv->set_mod_revision(old.mod_revision);
               prev_kv->set_version(old.version);

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -364,7 +364,7 @@ namespace app
           cmp.target() == etcdserverpb::Compare_CompareTarget_VALUE &&
           cmp.has_value())
         {
-          outcome = txn_compare(cmp.result(), value.value, cmp.value());
+          outcome = txn_compare(cmp.result(), value.get_data(), cmp.value());
         }
         else if (
           cmp.target() == etcdserverpb::Compare_CompareTarget_VERSION &&

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -152,7 +152,7 @@ namespace app
         auto* kv = range_response.add_kvs();
         kv->set_key(payload.key());
         auto value = value_option.value();
-        kv->set_value(value.value);
+        kv->set_value(value.value.decode());
         kv->set_create_revision(value.create_revision);
         kv->set_mod_revision(value.mod_revision);
         kv->set_version(value.version);
@@ -173,7 +173,7 @@ namespace app
             // add the kv to the response
             auto* kv = range_response.add_kvs();
             kv->set_key(key);
-            kv->set_value(value.value);
+            kv->set_value(value.value.decode());
             kv->set_create_revision(value.create_revision);
             kv->set_mod_revision(value.mod_revision);
             kv->set_version(value.version);
@@ -265,7 +265,7 @@ namespace app
             auto* prev_kv = delete_range_response.add_prev_kvs();
             prev_kv->set_key(payload.key());
             auto old_value = old_option.value();
-            prev_kv->set_value(old_value.value);
+            prev_kv->set_value(old_value.value.decode());
             prev_kv->set_create_revision(old_value.create_revision);
             prev_kv->set_mod_revision(old_value.mod_revision);
             prev_kv->set_version(old_value.version);
@@ -308,7 +308,7 @@ namespace app
               auto* prev_kv = delete_range_response.add_prev_kvs();
 
               prev_kv->set_key(key);
-              prev_kv->set_value(old.value);
+              prev_kv->set_value(old.value.decode());
               prev_kv->set_create_revision(old.create_revision);
               prev_kv->set_mod_revision(old.mod_revision);
               prev_kv->set_version(old.version);

--- a/src/app/kvstore.cpp
+++ b/src/app/kvstore.cpp
@@ -19,7 +19,7 @@ namespace app::store
 
   Value::Value(std::string v)
   {
-    data = std::vector(v.begin(), v.end());
+    data = std::vector<uint8_t>(v.begin(), v.end());
     create_revision = 0;
     mod_revision = 0;
     version = 1;

--- a/src/app/kvstore.cpp
+++ b/src/app/kvstore.cpp
@@ -5,7 +5,6 @@
 
 #include "ccf/app_interface.h"
 #include "ccf/common_auth_policies.h"
-#include "ccf/ds/hex.h"
 #include "ccf/http_query.h"
 #include "ccf/json_handler.h"
 #include "kv/untyped_map.h" // TODO(#22): private header
@@ -18,25 +17,9 @@ namespace app::store
 
   static constexpr auto RECORDS = "records";
 
-  HexString::HexString(std::string v)
-  {
-    value = ds::to_hex(v);
-  }
-
-  HexString::HexString() = default;
-
-  std::string HexString::decode()
-  {
-    const auto vec = ds::from_hex(value);
-    return std::string(vec.begin(), vec.end());
-  }
-
-  DECLARE_JSON_TYPE(HexString);
-  DECLARE_JSON_REQUIRED_FIELDS(HexString, value);
-
   Value::Value(std::string v)
   {
-    value = HexString(v);
+    data = std::vector(v.begin(), v.end());
     create_revision = 0;
     mod_revision = 0;
     version = 1;
@@ -45,8 +28,13 @@ namespace app::store
 
   Value::Value() = default;
 
+  std::string Value::get_data()
+  {
+    return std::string(data.begin(), data.end());
+  }
+
   DECLARE_JSON_TYPE(Value);
-  DECLARE_JSON_REQUIRED_FIELDS(Value, value, create_revision, version);
+  DECLARE_JSON_REQUIRED_FIELDS(Value, data, create_revision, version);
 
   // using K = std::string;
   // using V = Value;

--- a/src/app/kvstore.cpp
+++ b/src/app/kvstore.cpp
@@ -5,6 +5,7 @@
 
 #include "ccf/app_interface.h"
 #include "ccf/common_auth_policies.h"
+#include "ccf/ds/hex.h"
 #include "ccf/http_query.h"
 #include "ccf/json_handler.h"
 #include "kv/untyped_map.h" // TODO(#22): private header
@@ -17,9 +18,25 @@ namespace app::store
 
   static constexpr auto RECORDS = "records";
 
+  HexString::HexString(std::string v)
+  {
+    value = ds::to_hex(v);
+  }
+
+  HexString::HexString() = default;
+
+  std::string HexString::decode()
+  {
+    const auto vec = ds::from_hex(value);
+    return std::string(vec.begin(), vec.end());
+  }
+
+  DECLARE_JSON_TYPE(HexString);
+  DECLARE_JSON_REQUIRED_FIELDS(HexString, value);
+
   Value::Value(std::string v)
   {
-    value = v;
+    value = HexString(v);
     create_revision = 0;
     mod_revision = 0;
     version = 1;

--- a/src/app/kvstore.h
+++ b/src/app/kvstore.h
@@ -13,7 +13,7 @@ namespace app::store
   {
     // the actual value that the client wants written stored as a list of bytes
     // to avoid requiring valid utf-8 (for the json serialiser).
-    std::vector<char> data;
+    std::vector<uint8_t> data;
     // the revision that this entry was created (since the last delete).
     int64_t create_revision;
     // the latest modification of this entry (0 in the serialised field).

--- a/src/app/kvstore.h
+++ b/src/app/kvstore.h
@@ -9,10 +9,24 @@
 
 namespace app::store
 {
+  struct HexString
+  {
+    // The encoded string.
+    std::string value;
+
+    // Construct a hexstring from a plain byte string
+    HexString(std::string);
+    // Construct an empty hex string.
+    HexString();
+    // Unencode a hexstring
+    std::string decode();
+  };
+
   struct Value
   {
-    // the actual value that the client wants written.
-    std::string value;
+    // the actual value that the client wants written, encoded to hex to make it
+    // valid utf-8 (for the json serialiser).
+    HexString value;
     // the revision that this entry was created (since the last delete).
     int64_t create_revision;
     // the latest modification of this entry (0 in the serialised field).

--- a/src/app/kvstore.h
+++ b/src/app/kvstore.h
@@ -9,24 +9,11 @@
 
 namespace app::store
 {
-  struct HexString
-  {
-    // The encoded string.
-    std::string value;
-
-    // Construct a hexstring from a plain byte string
-    HexString(std::string);
-    // Construct an empty hex string.
-    HexString();
-    // Unencode a hexstring
-    std::string decode();
-  };
-
   struct Value
   {
-    // the actual value that the client wants written, encoded to hex to make it
-    // valid utf-8 (for the json serialiser).
-    HexString value;
+    // the actual value that the client wants written stored as a list of bytes
+    // to avoid requiring valid utf-8 (for the json serialiser).
+    std::vector<char> data;
     // the revision that this entry was created (since the last delete).
     int64_t create_revision;
     // the latest modification of this entry (0 in the serialised field).
@@ -38,6 +25,8 @@ namespace app::store
 
     Value(std::string v);
     Value();
+
+    std::string get_data();
   };
 
   class KVStore


### PR DESCRIPTION
This is needed as the json serialiser can't serialise non-utf8 characters in the string.