### PR TITLE
Add shared mutex for kvindex

### DIFF
--- a/src/app/index.cpp
+++ b/src/app/index.cpp
@@ -28,6 +28,8 @@ namespace app::index
   void KVIndexer::handle_committed_transaction(
     const ccf::TxID& tx_id, const kv::ReadOnlyStorePtr& store_ptr)
   {
+    std::unique_lock lock(mutex);
+
     // TODO(#47): handle deleted kvs
     CCF_APP_DEBUG("index: handling committed transaction {}", tx_id.seqno);
     current_txid = tx_id;
@@ -48,6 +50,7 @@ namespace app::index
 
   std::optional<ccf::SeqNo> KVIndexer::next_requested()
   {
+    std::shared_lock lock(mutex);
     return current_txid.seqno + 1;
   };
 
@@ -68,6 +71,8 @@ namespace app::index
 
   std::optional<KVIndexer::V> KVIndexer::get(const int64_t at, const K& key)
   {
+    std::shared_lock lock(mutex);
+
     CCF_APP_DEBUG("getting value from index with key {}", key);
     if (keys_to_values.contains(key))
     {
@@ -86,6 +91,7 @@ namespace app::index
     const KVIndexer::K& from,
     const KVIndexer::K& to)
   {
+    std::shared_lock lock(mutex);
     // iterate over the keys in keys_to_values
     auto lb = keys_to_values.lower_bound(from);
     auto ub = keys_to_values.lower_bound(to);
@@ -108,5 +114,4 @@ namespace app::index
       // user
     }
   }
-
 }; // namespace app::index

--- a/src/app/index.h
+++ b/src/app/index.h
@@ -7,6 +7,7 @@
 #include "kvstore.h"
 
 #include <map>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,8 @@ namespace app::index
 
     // a mapping from keys to the values those keys had at certain points.
     std::map<K, std::vector<V>> keys_to_values;
+
+    std::shared_mutex mutex;
 
   public:
     explicit KVIndexer(const std::string& map_name);


### PR DESCRIPTION
This ensures that there aren't races in the updates. This is particularly useful with compaction.