### PR TITLE
Move VERBOSE_LOGGING def to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(proto)
 option(
   PUBLIC_MAPS
   "If enabled, all keys and values are recorded in plaintext in the ledger (insecure!)"
-  OFF) 
+  OFF)
 
 option(VERBOSE_LOGGING "enable verbose logging" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,17 @@ add_ccf_app(
   protobuf.virtual)
 
 if(PUBLIC_MAPS)
+  message(STATUS "Using public maps")
   add_compile_definitions(PUBLIC_MAPS)
+else()
+  message(STATUS "Using private maps")
 endif()
+
 if(VERBOSE_LOGGING)
+  message(STATUS "Using verbose logging")
   add_compile_definitions(VERBOSE_LOGGING)
+else()
+  message(STATUS "Using terse logging")
 endif()
 
 # Generate an ephemeral signing key

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ add_subdirectory(proto)
 option(
   PUBLIC_MAPS
   "If enabled, all keys and values are recorded in plaintext in the ledger (insecure!)"
-  OFF)
+  OFF) 
+
+option(VERBOSE_LOGGING "enable verbose logging" OFF)
 
 add_ccf_app(
   lskv
@@ -37,6 +39,9 @@ add_ccf_app(
 
 if(PUBLIC_MAPS)
   add_compile_definitions(PUBLIC_MAPS)
+endif()
+if(VERBOSE_LOGGING)
+  add_compile_definitions(VERBOSE_LOGGING)
 endif()
 
 # Generate an ephemeral signing key

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Alternatively, it is possible to build a runtime image of this application via d
 $ docker build -t lskv-sgx -f Dockerfile.sgx .
 ```
 
+## Build options
+
+The cmake build can be configured with the following lskv-specific options:
+
+- `PUBLIC_MAPS`: store data in public maps (publicly visible in the ledger)
+- `VERBOSE_LOGGING`: enable verbose logging which may output private data to logs
+
 ## Testing
 
 ### Etcd integration tests

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#define VERBOSE_LOGGING
-
 #include "ccf/app_interface.h"
 #include "ccf/common_auth_policies.h"
 #include "ccf/crypto/sha256.h"

--- a/src/app/index.cpp
+++ b/src/app/index.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#define VERBOSE_LOGGING
-
 #include "index.h"
 
 #include "ccf/app_interface.h"

--- a/src/app/leases.cpp
+++ b/src/app/leases.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#define VERBOSE_LOGGING
-
 #include "leases.h"
 
 #include <chrono> // NOLINT(build/c++11)


### PR DESCRIPTION
This means we can alter the log level when building without altering the source.