### PR TITLE
Add EXTRA_INCLUDES for building sgx protos

### DIFF
--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -46,7 +46,7 @@ foreach(proto_file ${PROTO_FILES})
     add_enclave_library(
       ${PROTO_NAME_WE}.enclave
       ${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME_WE}.pb.cc
-      ${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME_WE}.pb.h)
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME_WE}.pb.h ${EXTRA_INCLUDES})
     target_include_directories(
       ${PROTO_NAME_WE}.enclave PUBLIC ${PROTOBUF_INCLUDE_DIR}
                                       ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Fix the missing dependency within sgx builds: https://github.com/microsoft/LSKV/actions/runs/3426620951/jobs/5708645846