### PR TITLE
Fix notice check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the
-# MIT license.
+# MIT License.
 
 cmake_minimum_required(VERSION 3.16)
 

--- a/Dockerfile.ignore
+++ b/Dockerfile.ignore
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 FROM busybox
 WORKDIR /build-context
 COPY . .

--- a/Dockerfile.sgx
+++ b/Dockerfile.sgx
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 # Build
 FROM mcr.microsoft.com/ccf/app/dev:3.0.0-rc1-sgx as builder
 

--- a/Dockerfile.virtual
+++ b/Dockerfile.virtual
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 # Build
 FROM mcr.microsoft.com/ccf/app/dev:3.0.0-rc1-virtual as builder
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 BUILD=build
 CCF_PREFIX_VIRTUAL=/opt/ccf_virtual
 CCF_PREFIX_SGX=/opt/ccf_sgx

--- a/benchmark/k6.js
+++ b/benchmark/k6.js
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { check } from "k6";
 import http from "k6/http";
 

--- a/constitution/actions.js
+++ b/constitution/actions.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 class Action {
   constructor(validate, apply) {
     this.validate = validate;

--- a/constitution/apply.js
+++ b/constitution/apply.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 export function apply(proposal, proposalId) {
   const proposed_actions = JSON.parse(proposal)["actions"];
   for (const proposed_action of proposed_actions) {

--- a/constitution/resolve.js
+++ b/constitution/resolve.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 export function resolve(proposal, proposerId, votes) {
   const memberVoteCount = votes.filter((v) => v.vote).length;
 

--- a/constitution/validate.js
+++ b/constitution/validate.js
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 export function validate(input) {
   let proposal = JSON.parse(input);
   let errors = [];

--- a/oe_sign.conf
+++ b/oe_sign.conf
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 # Enclave settings:
 NumHeapPages=50000
 NumStackPages=1024

--- a/patches/0001-etcd-patches.patch
+++ b/patches/0001-etcd-patches.patch
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 diff --git a/pkg/report/report.go b/pkg/report/report.go
 index 36d09b9d5..7db5a1d83 100644
 --- a/pkg/report/report.go

--- a/patches/k6-micro.diff
+++ b/patches/k6-micro.diff
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 diff --git a/output/csv/output.go b/output/csv/output.go
 index 582ad7e5..c4e94ba2 100644
 --- a/output/csv/output.go
@@ -9,5 +11,5 @@ index 582ad7e5..c4e94ba2 100644
 -		row[1] = strconv.FormatInt(sample.Time.Unix(), 10)
 +		row[1] = strconv.FormatInt(sample.Time.UnixMicro(), 10)
  	}
- 
+
  	row[2] = fmt.Sprintf("%f", sample.Value)

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the
-# Apache 2.0 License.
+# MIT License.
 
 # protoc should be installed under /opt/protoc
 set(PROTOC_BINARY_PATH "/opt/protoc/bin/protoc")

--- a/proto/lskvserver.proto
+++ b/proto/lskvserver.proto
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 syntax = "proto3";
 
 import "etcd.proto";

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 cimetrics==0.3.12
 pandas==1.5.0
 notebook==6.4.12

--- a/scripts/check-cmake-format.sh
+++ b/scripts/check-cmake-format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the Apache 2.0 License.
+# Licensed under the MIT License.
 
 set -u
 

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the Apache 2.0 License.
+# Licensed under the MIT License.
 
 set -u
 

--- a/scripts/check-issues.sh
+++ b/scripts/check-issues.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the Apache 2.0 License.
+# Licensed under the MIT License.
 
 todos=$(git grep --line-number -o -E 'TODO\(#[0-9]+\)' -- ':!3rdparty/protobuf')
 

--- a/scripts/check-todo.sh
+++ b/scripts/check-todo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the Apache 2.0 License.
+# Licensed under the MIT License.
 
 set -u
 

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -44,7 +44,7 @@ fi
 
 echo "$CHECK_DELIMITER"
 echo "-- Copyright notice headers"
-git ls-files -- . ':!:3rdparty/' | xargs python3.8 "$SCRIPT_DIR"/notice_check.py
+git ls-files -- src benchmark tests ':!:3rdparty/' ':!:.github/' ':!:*.ipynb' ':!:*.md' ':!:requirements.txt' | xargs python3 "$SCRIPT_DIR"/notice_check.py
 
 echo "$CHECK_DELIMITER"
 echo "-- CMake format"

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the Apache 2.0 License.
+# Licensed under the MIT License.
 
 set -e
 
@@ -44,7 +44,7 @@ fi
 
 echo "$CHECK_DELIMITER"
 echo "-- Copyright notice headers"
-git ls-files -- src benchmark tests ':!:3rdparty/' ':!:.github/' ':!:*.ipynb' ':!:*.md' ':!:requirements.txt' | xargs python3 "$SCRIPT_DIR"/notice_check.py
+python3 "$SCRIPT_DIR"/notice_check.py
 
 echo "$CHECK_DELIMITER"
 echo "-- CMake format"

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -43,10 +43,6 @@ else
 fi
 
 echo "$CHECK_DELIMITER"
-echo "-- Copyright notice headers"
-python3 "$SCRIPT_DIR"/notice_check.py
-
-echo "$CHECK_DELIMITER"
 echo "-- CMake format"
 if [ $FIX -ne 0 ]; then
   "$SCRIPT_DIR"/check-cmake-format.sh -f cmake samples src tests CMakeLists.txt
@@ -68,6 +64,10 @@ source ${VENV_DIR}/bin/activate
 pip install -U pip
 pip install -U wheel black[jupyter] pylint mypy cpplint 1>/dev/null
 pip install -r requirements.txt
+
+echo "$CHECK_DELIMITER"
+echo "-- Copyright notice headers"
+python3 "$SCRIPT_DIR"/notice_check.py
 
 echo "$CHECK_DELIMITER"
 echo "-- Python format"

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -44,7 +44,7 @@ fi
 
 echo "$CHECK_DELIMITER"
 echo "-- Copyright notice headers"
-python3.8 "$SCRIPT_DIR"/notice_check.py
+git ls-files -- . ':!:3rdparty/' | xargs python3.8 "$SCRIPT_DIR"/notice_check.py
 
 echo "$CHECK_DELIMITER"
 echo "-- CMake format"

--- a/scripts/notice_check.py
+++ b/scripts/notice_check.py
@@ -9,38 +9,71 @@ import subprocess
 import sys
 from typing import List
 
-NOTICE_LINES_CCF = [
-    "Copyright (c) Microsoft Corporation. All rights reserved.",
-    "Licensed under the MIT License.",
-]
+from loguru import logger
 
-PREFIXES_CCF = [
-    os.linesep.join([prefix + " " + line for line in NOTICE_LINES_CCF])
-    for prefix in ["//", "--", "#"]
-]
-PREFIXES_CCF.append("#!/bin/bash" + os.linesep + "#")
-PREFIXES_CCF.append("#!/usr/bin/env sh" + os.linesep + "#")
-PREFIXES_CCF.append("#!/usr/bin/env bash" + os.linesep + "#")
-PREFIXES_CCF.append("#!/usr/bin/env python3" + os.linesep + "#")
+license_header = "Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT License."
 
+comment_prefixes = ["//", "#"]
 
-def has_notice(path: str, prefixes: List[str]) -> bool:
+def extract_potential_license(lines:List[str])->str:
+    license_lines = []
+    for line in lines:
+        was_comment = False
+        for comment_prefix in comment_prefixes:
+            if line.startswith(comment_prefix):
+                line = line.lstrip(comment_prefix)
+                was_comment = True
+        if not was_comment:
+            logger.debug("stopping at line: {}", line.strip())
+            return " ".join(license_lines)
+        license_lines.append(line.strip())
+
+    return " ".join(license_lines)
+
+def has_notice(path: str) -> bool:
     """
     Check that the given file has a notice.
     """
     with open(path, "r", encoding="utf-8") as file:
-        text = file.read()
-        for prefix in prefixes:
-            if text.startswith(prefix):
-                return True
+        lines = file.readlines()
+        license_lines = extract_potential_license(lines)
+        if license_header in license_lines:
+            return True
+        logger.debug("   found: {}", license_lines)
+        logger.debug("expected: {}", license_header)
+
     return False
 
+def git_ls_files() -> List[str]:
+    excluded = [
+        "3rdparty/", # these aren't ours
+        "LICENSE", # don't need a license on the license
+        "*.json", # can't add comments to these files
+        "*.ipynb", # can't add comments to these files
+        "*.md", # just documentation
+        ".gitmodules", # not a source file
+        ".gitignore", # not a source file
+        ".dockerignore", # not a source file
+        ".clang-format", # not a source file
+        "proto/etcd.proto", # mostly not ours
+        "proto/status.proto", # mostly not ours
+        ".github/workflows", # not source files
+    ]
+    excluded = [f":!:{e}" for e in excluded]
+    cmd = ["git", "ls-files", "--", "."] + excluded
+    res = subprocess.run(cmd, check=True, capture_output=True)
+    return res.stdout.decode("utf-8").strip().split("\n")
 
 if __name__ == "__main__":
-    files = sys.argv[1:]
+    logger.remove()
+    logger.add(sink=sys.stdout, level="WARNING")
+
+    files = git_ls_files()
+
     missing = 0
     for file in files:
-        if not has_notice(file, PREFIXES_CCF):
+        logger.info("Checking {}", file)
+        if not has_notice(file):
             missing += 1
-            print(f"Copyright notice missing from {file}")
+            logger.warning("Copyright notice missing from {}", file)
     sys.exit(missing)

--- a/scripts/notice_check.py
+++ b/scripts/notice_check.py
@@ -35,6 +35,7 @@ def has_notice(path: str, prefixes: List[str]) -> bool:
                 return True
     return False
 
+
 if __name__ == "__main__":
     files = sys.argv[1:]
     missing = 0

--- a/scripts/notice_check.py
+++ b/scripts/notice_check.py
@@ -4,7 +4,6 @@
 Script to check that source files have license headers.
 """
 
-import os
 import subprocess
 import sys
 from typing import List


### PR DESCRIPTION
This reworks the `notice_check.py` to use `git ls-files` and exclude some things from that. It also reworks the logic for checking for the license lines to be a bit more robust in the face of formatting.