### PR TITLE
Require user certs on the endpoints

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -304,6 +304,13 @@ namespace app
       return *res;
     }
 
+    static ccf::AuthnPolicies auth_policies()
+    {
+      ccf::AuthnPolicies policies;
+      policies.push_back(ccf::user_cert_auth_policy);
+      return policies;
+    }
+
     template <typename In, typename Out>
     void install_endpoint_with_header_ro(
       const std::string& package,
@@ -326,7 +333,7 @@ namespace app
           auto res = post_commit<Out>(ctx, tx_id);
           ccf::grpc::set_grpc_response(res, ctx.rpc_ctx);
         },
-        ccf::no_auth_required)
+        auth_policies())
         .install();
       make_read_only_endpoint_with_local_commit_handler(
         path,
@@ -336,7 +343,7 @@ namespace app
           auto res = post_commit<Out>(ctx, tx_id);
           app::json_grpc::set_json_grpc_response(res, ctx.rpc_ctx);
         },
-        ccf::no_auth_required)
+        auth_policies())
         .install();
     }
 
@@ -362,7 +369,7 @@ namespace app
           auto res = post_commit<Out>(ctx, tx_id);
           ccf::grpc::set_grpc_response(res, ctx.rpc_ctx);
         },
-        ccf::no_auth_required)
+        auth_policies())
         .install();
       make_endpoint_with_local_commit_handler(
         path,
@@ -372,7 +379,7 @@ namespace app
           auto res = post_commit<Out>(ctx, tx_id);
           app::json_grpc::set_json_grpc_response(res, ctx.rpc_ctx);
         },
-        ccf::no_auth_required)
+        auth_policies())
         .install();
     }
 
@@ -407,7 +414,7 @@ namespace app
           [](ccf::endpoints::ReadOnlyEndpointContext& ctx) {
             return txid_from_body(ccf::grpc::get_grpc_payload<In>(ctx.rpc_ctx));
           }),
-        ccf::no_auth_required)
+        auth_policies())
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
       make_read_only_endpoint(
@@ -421,7 +428,7 @@ namespace app
             return txid_from_body(
               app::json_grpc::get_json_grpc_payload<In>(ctx.rpc_ctx));
           }),
-        ccf::no_auth_required)
+        auth_policies())
         .set_forwarding_required(ccf::endpoints::ForwardingRequired::Never)
         .install();
     }

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,6 +8,7 @@ Common utils for testing.
 import base64
 import os
 import time
+from http import HTTPStatus
 from subprocess import PIPE, Popen
 from typing import Any, Dict, List
 
@@ -202,6 +203,18 @@ def fixture_http1_client(sandbox):
         yield HttpClient(client)
 
 
+@pytest.fixture(name="http1_client_unauthenticated", scope="module")
+def fixture_http1_client_unauthenticated(sandbox):
+    """
+    Make an unauthenticated http1 client for the sandbox.
+    """
+    cacert = sandbox.cacert()
+    with httpx.Client(
+        http2=False, verify=cacert, base_url="https://127.0.0.1:8000"
+    ) as client:
+        yield HttpClient(client)
+
+
 def b64encode(in_str: str) -> str:
     """
     Base64 encode a string.
@@ -237,7 +250,7 @@ class HttpClient:
             i += 1
             tx_status = self.tx_status(txid)
             logger.debug("tx_status: {}", tx_status)
-            if tx_status.status_code == 200:
+            if tx_status.status_code == HTTPStatus.OK:
                 body = tx_status.json()
                 if "status" in body:
                     status = body["status"]

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -5,11 +5,18 @@
 Test a single node
 """
 
+from http import HTTPStatus
+
 from loguru import logger
 
 # pylint: disable=unused-import
 # pylint: disable=no-name-in-module
-from test_common import b64decode, fixture_http1_client, fixture_sandbox
+from test_common import (
+    b64decode,
+    fixture_http1_client,
+    fixture_http1_client_unauthenticated,
+    fixture_sandbox,
+)
 
 
 # pylint: disable=redefined-outer-name
@@ -18,7 +25,20 @@ def test_starts(http1_client):
     Test that the sandbox starts.
     """
     res = http1_client.raw().get("api")
-    assert res.status_code == 200
+    assert res.status_code == HTTPStatus.OK
+
+
+# pylint: disable=redefined-outer-name
+def test_unauthenticated(http1_client_unauthenticated):
+    """
+    Test that the unauthenticated users can't interact.
+    """
+    res = http1_client_unauthenticated.put("foo", "bar")
+    assert res.status_code == HTTPStatus.UNAUTHORIZED
+    res = http1_client_unauthenticated.get("foo")
+    assert res.status_code == HTTPStatus.UNAUTHORIZED
+    res = http1_client_unauthenticated.delete("foo")
+    assert res.status_code == HTTPStatus.UNAUTHORIZED
 
 
 # pylint: disable=redefined-outer-name
@@ -81,7 +101,7 @@ def check_response(res):
     Check a response to be success.
     """
     logger.info("res: {} {}", res.status_code, res.text)
-    assert res.status_code == 200
+    assert res.status_code == HTTPStatus.OK
     check_header(res.json())
 
 


### PR DESCRIPTION
Whilst not fully authenticating users with permissions this does mean they have to connect with a client cert.

Fixes #168 