### PR TITLE
Add TxStatus endpoint

### DIFF
--- a/proto/lskvserver.proto
+++ b/proto/lskvserver.proto
@@ -67,6 +67,7 @@ message GetReceiptResponse
   Receipt receipt = 2;
 }
 
+// https://microsoft.github.io/CCF/main/use_apps/verify_tx.html#checking-for-commit
 message TxStatusRequest
 {
   int64 revision = 1;

--- a/proto/lskvserver.proto
+++ b/proto/lskvserver.proto
@@ -66,3 +66,31 @@ message GetReceiptResponse
   etcdserverpb.ResponseHeader header = 1;
   Receipt receipt = 2;
 }
+
+message TxStatusRequest
+{
+  int64 revision = 1;
+  uint64 raft_term = 2;
+}
+
+message TxStatusResponse
+{
+  etcdserverpb.ResponseHeader header = 1;
+  enum Status {
+    // This node has not received this transaction, and knows nothing about it
+    Unknown = 0;
+    // This node has this transaction locally, but has not yet heard that the
+    // transaction has been committed by the distributed consensus
+    Pending = 1;
+    // This node has seen that this transaction is committed, it is an
+    // irrevocable and durable part of the service's transaction history
+    Committed = 2;
+    // This node knows that the given transaction cannot be committed. This may
+    // mean there has been a view change, and a previously pending transaction
+    // has been lost (the original request should be resubmitted and will be
+    // given a new Transaction ID). This also describes IDs which are known to
+    // be impossible given the currently committed IDs
+    Invalid = 3;
+  }
+  Status status = 2;
+}

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1060,7 +1060,12 @@ namespace app
       ccf::View view = payload.raft_term();
       ccf::SeqNo seqno = payload.revision();
       ccf::TxStatus status;
-      get_status_for_txid_v1(view, seqno, status);
+      auto res = get_status_for_txid_v1(view, seqno, status);
+      if (res != ccf::ApiResult::OK)
+      {
+        CCF_APP_FAIL(
+          "failed to get status for txid {}.{}: {}", view, seqno, res);
+      }
 
       switch (status)
       {
@@ -1076,6 +1081,8 @@ namespace app
         case ccf::TxStatus::Invalid:
           response.set_status(lskvserverpb::TxStatusResponse_Status_Invalid);
           break;
+        default:
+          CCF_APP_FAIL("unknown txstatus {}", status);
       }
 
       return ccf::grpc::make_success(response);

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -127,6 +127,21 @@ namespace app
         etcdserverpb::CompactionResponse>(
         etcdserverpb, kv, "Compact", "/v3/kv/compact", compact);
 
+      auto txstatus = [this](
+                        ccf::endpoints::CommandEndpointContext& ctx,
+                        lskvserverpb::TxStatusRequest&& payload) {
+        return this->tx_status(ctx, std::move(payload));
+      };
+
+      install_command_endpoint<
+        lskvserverpb::TxStatusRequest,
+        lskvserverpb::TxStatusResponse>(
+        etcdserverpb,
+        maintenance,
+        "TxStatus",
+        "/v3/maintenance/tx_status",
+        txstatus);
+
       auto lease_grant = [this](
                            ccf::endpoints::EndpointContext& ctx,
                            etcdserverpb::LeaseGrantRequest&& payload) {
@@ -1027,6 +1042,41 @@ namespace app
 
       revoke_expired_leases(ctx.tx);
       kvindex->compact(payload.revision());
+
+      return ccf::grpc::make_success(response);
+    }
+
+    ccf::grpc::GrpcAdapterResponse<lskvserverpb::TxStatusResponse> tx_status(
+      ccf::endpoints::CommandEndpointContext& ctx,
+      lskvserverpb::TxStatusRequest&& payload)
+    {
+      CCF_APP_DEBUG(
+        "TxStatus = term:{} revision:{}",
+        payload.raft_term(),
+        payload.revision());
+
+      lskvserverpb::TxStatusResponse response;
+
+      ccf::View view = payload.raft_term();
+      ccf::SeqNo seqno = payload.revision();
+      ccf::TxStatus status;
+      get_status_for_txid_v1(view, seqno, status);
+
+      switch (status)
+      {
+        case ccf::TxStatus::Unknown:
+          response.set_status(lskvserverpb::TxStatusResponse_Status_Unknown);
+          break;
+        case ccf::TxStatus::Pending:
+          response.set_status(lskvserverpb::TxStatusResponse_Status_Pending);
+          break;
+        case ccf::TxStatus::Committed:
+          response.set_status(lskvserverpb::TxStatusResponse_Status_Committed);
+          break;
+        case ccf::TxStatus::Invalid:
+          response.set_status(lskvserverpb::TxStatusResponse_Status_Invalid);
+          break;
+      }
 
       return ccf::grpc::make_success(response);
     }

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -244,11 +244,10 @@ class HttpClient:
         """
         Wait for a commit to be successful.
         """
-        txid = f"{term}.{rev}"
         i = 0
         while True:
             i += 1
-            tx_status = self.tx_status(txid)
+            tx_status = self.tx_status(term, rev)
             logger.debug("tx_status: {}", tx_status)
             if tx_status.status_code == HTTPStatus.OK:
                 body = tx_status.json()
@@ -266,12 +265,6 @@ class HttpClient:
             if i > tries:
                 raise Exception("failed to wait for commit")
             time.sleep(0.1)
-
-    def tx_status(self, txid: str):
-        """
-        Get the status of a transaction id.
-        """
-        return self.client.get(f"/app/tx?transaction_id={txid}")
 
     def get(self, key: str, range_end: str = "", rev: int = 0):
         """
@@ -328,6 +321,14 @@ class HttpClient:
         logger.info("LeaseKeepAlive: {}", lease_id)
         j = {"ID": lease_id}
         return self.client.post("/v3/lease/keepalive", json=j)
+
+    def tx_status(self, term: int, rev: int):
+        """
+        Check the status of a transaction.
+        """
+        logger.info("TxStatus: {} {}", term, rev)
+        j: Dict[str, Any] = {"raftTerm": term, "revision": rev}
+        return self.client.post("/v3/maintenance/tx_status", json=j)
 
     def status(self):
         """

--- a/tests/test_single.py
+++ b/tests/test_single.py
@@ -186,9 +186,9 @@ def test_tx_status(http1_client):
     res = http1_client.tx_status(term, 100000)
     check_response(res)
     # a tx far in the future may have been submitted by another node
-    assert "status" not in res.json() # missing status means Unknown
+    assert "status" not in res.json()  # missing status means Unknown
 
-    res = http1_client.tx_status(int(term)+1, int(rev)-1)
+    res = http1_client.tx_status(int(term) + 1, int(rev) - 1)
     check_response(res)
     status = res.json()["status"]
     assert status == "Invalid"


### PR DESCRIPTION
A more native way to get the status of a transaction id.

Wasn't sure which service it would be best under, went with maintenace for similarity to `Status`. I don't think it fits into `KV` because other services can generate transactions...