### PR TITLE
Allow pull request ci on stacked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Currently CI only runs on pull requests that target main, meaning stacked PRs don't get any CI run until the dependent branch is merged and the stacked PR is updated to target main. It would instead be nice to run CI on stacked PRs so we can check things work.