### PR TITLE
Default `LSKV_VERSION` if no tag is found

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -14,7 +14,8 @@ if(NOT RETURN_CODE STREQUAL "0")
   set(LSKV_VERSION "0.0.0")
   message(
     WARNING
-    "Could not find any tag in repository. Defaulting LSKV version to ${LSKV_VERSION}")
+      "Could not find any tag in repository. Defaulting LSKV version to ${LSKV_VERSION}"
+  )
 endif()
 
 # strip 'v' prefix from version

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -9,8 +9,10 @@ execute_process(
   OUTPUT_VARIABLE "LSKV_VERSION"
   OUTPUT_STRIP_TRAILING_WHITESPACE
   RESULT_VARIABLE RETURN_CODE)
+
 if(NOT RETURN_CODE STREQUAL "0")
-  message(FATAL_ERROR "Error calling git describe")
+  message(WARNING "Could not find any tag in repository. Defaulting LSKV version to 0.0.0")
+  set(LSKV_VERSION "0.0.0")
 endif()
 
 # strip 'v' prefix from version

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -11,7 +11,9 @@ execute_process(
   RESULT_VARIABLE RETURN_CODE)
 
 if(NOT RETURN_CODE STREQUAL "0")
-  message(WARNING "Could not find any tag in repository. Defaulting LSKV version to 0.0.0")
+  message(
+    WARNING
+      "Could not find any tag in repository. Defaulting LSKV version to 0.0.0")
   set(LSKV_VERSION "0.0.0")
 endif()
 

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -11,10 +11,10 @@ execute_process(
   RESULT_VARIABLE RETURN_CODE)
 
 if(NOT RETURN_CODE STREQUAL "0")
+  set(LSKV_VERSION "0.0.0")
   message(
     WARNING
-      "Could not find any tag in repository. Defaulting LSKV version to 0.0.0")
-  set(LSKV_VERSION "0.0.0")
+    "Could not find any tag in repository. Defaulting LSKV version to ${LSKV_VERSION}")
 endif()
 
 # strip 'v' prefix from version


### PR DESCRIPTION
This is useful when the repo is cloned without tags, or if the source is retrieved from a tarball.