### PR TITLE
No longer push images to CCF ACR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ACR_REGISTRY: ccfmsrc.azurecr.io
   DOCKER_BUILDKIT: 1 # https://docs.docker.com/develop/develop-images/build_enhancements/
 
 jobs:
@@ -56,7 +55,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build container
-        run: docker build -t $ACR_REGISTRY/public/lskv:latest-virtual -f Dockerfile.virtual .
+        run: docker build -t lskv:latest-virtual -f Dockerfile.virtual .
 
   build-docker-sgx:
     runs-on: ubuntu-20.04
@@ -68,7 +67,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build container
-        run: docker build -t $ACR_REGISTRY/public/lskv:latest-sgx -f Dockerfile.sgx .
+        run: docker build -t lskv:latest-sgx -f Dockerfile.sgx .
 
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build containers
-        run: | 
+        run: |
           docker build -t lskv:latest-virtual -f Dockerfile.virtual .
           docker build -t lskv:latest-sgx -f Dockerfile.sgx .
 

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -8,12 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  ACR_REGISTRY: ccfmsrc.azurecr.io
-  ACR_TOKEN_NAME: lskv-push-token
   DOCKER_BUILDKIT: 1 # https://docs.docker.com/develop/develop-images/build_enhancements/
 
 jobs:
-  publish-docker-virtual:
+  publish:
     runs-on: ubuntu-20.04
 
     steps:
@@ -22,58 +20,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build container
-        run: docker build -t $ACR_REGISTRY/public/lskv:latest-virtual -f Dockerfile.virtual .
-
-      - name: Log in to registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: docker login -u $ACR_TOKEN_NAME -p ${{ secrets.ACR_LSKV_PUSH_TOKEN_PASSWORD }} $ACR_REGISTRY
-
-      - name: Push virtual image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: docker push $ACR_REGISTRY/public/lskv:latest-virtual
-
-  publish-docker-sgx:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Build container
-        run: docker build -t $ACR_REGISTRY/public/lskv:latest-sgx -f Dockerfile.sgx .
-
-      - name: Log in to registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: docker login -u $ACR_TOKEN_NAME -p ${{ secrets.ACR_LSKV_PUSH_TOKEN_PASSWORD }} $ACR_REGISTRY
-
-      - name: Push sgx image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: docker push $ACR_REGISTRY/public/lskv:latest-sgx
-
-  publish-binaries:
-    runs-on: ubuntu-20.04
-    needs:
-      - publish-docker-virtual
-      - publish-docker-sgx
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Download images
-        run: |
-          docker pull $ACR_REGISTRY/public/lskv:latest-virtual
-          docker pull $ACR_REGISTRY/public/lskv:latest-sgx
+      - name: Build containers
+        run: | 
+          docker build -t lskv:latest-virtual -f Dockerfile.virtual .
+          docker build -t lskv:latest-sgx -f Dockerfile.sgx .
 
       - name: Copy files out of images
         run: |
-          docker create --name lskv-virtual $ACR_REGISTRY/public/lskv:latest-virtual
+          docker create --name lskv-virtual lskv:latest-virtual
           docker cp lskv-virtual:/app/liblskv.virtual.so liblskv.virtual.so
           docker rm lskv-virtual
 
-          docker create --name lskv-sgx $ACR_REGISTRY/public/lskv:latest-sgx
+          docker create --name lskv-sgx lskv:latest-sgx
           docker cp lskv-sgx:/app/liblskv.enclave.so.signed liblskv.enclave.so.signed
           docker rm lskv-sgx
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,10 +19,10 @@ jobs:
           fetch-depth: 0
 
       - name: Build containers
-        run: | 
+        run: |
           docker build -t lskv:${{ github.ref }}-virtual -f Dockerfile.virtual .
           docker build -t lskv:${{ github.ref }}-sgx -f Dockerfile.sgx .
-      
+
       - name: Copy files out of images
         run: |
           docker create --name lskv-virtual lskv:${{ github.ref }}-virtual
@@ -32,7 +32,7 @@ jobs:
           docker create --name lskv-sgx lskv:${{ github.ref }}-sgx
           docker cp lskv-sgx:/app/liblskv.enclave.so.signed liblskv.enclave.so.signed
           docker rm lskv-sgx
-      
+
       - name: Publish ${{ github.ref }} release
         uses: softprops/action-gh-release@v1
         with:
@@ -40,4 +40,4 @@ jobs:
           tag_name: ${{ github.ref }}
           files: |
             liblskv.virtual.so
-            liblskv.enclave.so.signed      
+            liblskv.enclave.so.signed

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,12 +6,10 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
 env:
-  ACR_REGISTRY: ccfmsrc.azurecr.io
-  ACR_TOKEN_NAME: lskv-push-token
   DOCKER_BUILDKIT: 1 # https://docs.docker.com/develop/develop-images/build_enhancements/
 
 jobs:
-  publish-docker-virtual:
+  publish:
     runs-on: ubuntu-20.04
 
     steps:
@@ -20,57 +18,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build container
-        run: docker build -t $ACR_REGISTRY/public/lskv:${{ github.ref }}-virtual -f Dockerfile.virtual .
-
-      - name: Log in to registry
-        run: docker login -u $ACR_TOKEN_NAME -p ${{ secrets.ACR_LSKV_PUSH_TOKEN_PASSWORD }} $ACR_REGISTRY
-
-      - name: Push virtual image
-        run: docker push $ACR_REGISTRY/public/lskv:${{ github.ref }}-virtual
-
-  publish-docker-sgx:
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Build container
-        run: docker build -t $ACR_REGISTRY/public/lskv:${{ github.ref }}-sgx -f Dockerfile.sgx .
-
-      - name: Log in to registry
-        run: docker login -u $ACR_TOKEN_NAME -p ${{ secrets.ACR_LSKV_PUSH_TOKEN_PASSWORD }} $ACR_REGISTRY
-
-      - name: Push sgx image
-        run: docker push $ACR_REGISTRY/public/lskv:${{ github.ref }}-sgx
-
-  publish-binaries:
-    runs-on: ubuntu-20.04
-    needs:
-      - publish-docker-virtual
-      - publish-docker-sgx
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Download images
-        run: |
-          docker pull $ACR_REGISTRY/public/lskv:${{ github.ref }}-virtual
-          docker pull $ACR_REGISTRY/public/lskv:${{ github.ref }}-sgx
-
+      - name: Build containers
+        run: | 
+          docker build -t lskv:${{ github.ref }}-virtual -f Dockerfile.virtual .
+          docker build -t lskv:${{ github.ref }}-sgx -f Dockerfile.sgx .
+      
       - name: Copy files out of images
         run: |
-          docker create --name lskv-virtual $ACR_REGISTRY/public/lskv:${{ github.ref }}-virtual
+          docker create --name lskv-virtual lskv:${{ github.ref }}-virtual
           docker cp lskv-virtual:/app/liblskv.virtual.so liblskv.virtual.so
           docker rm lskv-virtual
 
-          docker create --name lskv-sgx $ACR_REGISTRY/public/lskv:${{ github.ref }}-sgx
+          docker create --name lskv-sgx lskv:${{ github.ref }}-sgx
           docker cp lskv-sgx:/app/liblskv.enclave.so.signed liblskv.enclave.so.signed
           docker rm lskv-sgx
-
+      
       - name: Publish ${{ github.ref }} release
         uses: softprops/action-gh-release@v1
         with:
@@ -78,4 +40,4 @@ jobs:
           tag_name: ${{ github.ref }}
           files: |
             liblskv.virtual.so
-            liblskv.enclave.so.signed
+            liblskv.enclave.so.signed      

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ build-sgx: .venv
 
 .PHONY: build-docker-virtual
 build-docker-virtual:
-	docker build -t ccfmsrc.azurecr.io/public/lskv:latest-virtual -f Dockerfile.virtual .
+	docker build -t lskv:latest-virtual -f Dockerfile.virtual .
 
 .PHONY: build-docker-sgx
 build-docker-sgx:
-	docker build -t ccfmsrc.azurecr.io/public/lskv:latest-sgx -f Dockerfile.sgx .
+	docker build -t lskv:latest-sgx -f Dockerfile.sgx .
 
 .PHONY: build-docker
 build-docker: build-docker-virtual build-docker-sgx

--- a/benchmark/lskv_cluster.py
+++ b/benchmark/lskv_cluster.py
@@ -665,7 +665,7 @@ if __name__ == "__main__":
     parser.add_argument("--nodes", type=int, default=1)
     parser.add_argument("--enclave", type=str, default="virtual")
     parser.add_argument(
-        "--image", type=str, default="ccfmsrc.azurecr.io/public/lskv:latest"
+        "--image", type=str, default="lskv:latest"
     )
     parser.add_argument("--http-version", type=int, default="2")
     parser.add_argument("--worker-threads", type=int, default="0")

--- a/benchmark/lskv_cluster.py
+++ b/benchmark/lskv_cluster.py
@@ -682,9 +682,7 @@ if __name__ == "__main__":
     parser.add_argument("--workspace", type=str, default="workspace")
     parser.add_argument("--nodes", type=int, default=1)
     parser.add_argument("--enclave", type=str, default="virtual")
-    parser.add_argument(
-        "--image", type=str, default="lskv:latest"
-    )
+    parser.add_argument("--image", type=str, default="lskv:latest")
     parser.add_argument("--http-version", type=int, default="2")
     parser.add_argument("--worker-threads", type=int, default="0")
     parser.add_argument("--sig-tx-interval", type=int, default="5000")

--- a/constitution/resolve.js
+++ b/constitution/resolve.js
@@ -12,8 +12,8 @@ export function resolve(proposal, proposerId, votes) {
     }
   });
 
-  // A majority of members can accept a proposal.
-  if (memberVoteCount > Math.floor(activeMemberCount / 2)) {
+  // A single member can accept a proposal.
+  if (memberVoteCount > 0 && activeMemberCount > 0) {
     return "Accepted";
   }
 


### PR DESCRIPTION
As the CCF Azure Container Registry should now only be used for CCF images, we no longer push images to this ACR on release. 