### PR TITLE
Check whether reads are serializable

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -457,6 +457,12 @@ namespace app
         payload.range_end().size(),
         payload.range_end());
 
+      if (!payload.serializable())
+      {
+        return ccf::grpc::make_error<etcdserverpb::RangeResponse>(
+          GRPC_STATUS_FAILED_PRECONDITION,
+          "linearizable reads are not yet supported");
+      }
       if (payload.sort_order() != etcdserverpb::RangeRequest_SortOrder_NONE)
       {
         return ccf::grpc::make_error<etcdserverpb::RangeResponse>(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -87,7 +87,7 @@ class Sandbox:
                 "POST",
                 f"https://127.0.0.1:{self.port}/v3/kv/range",
                 "-d",
-                '{"key":"bWlzc2luZyBrZXkK"}',
+                '{"key":"bWlzc2luZyBrZXkK","serializable":true}',
                 "-H",
                 "Content-Type: application/json",
             ]
@@ -338,6 +338,7 @@ class HttpClient:
         logger.info("Get: {} {} {} {}", key, range_end, rev, limit)
         req = etcd_pb2.RangeRequest()
         req.key = key.encode("utf-8")
+        req.serializable = True
         if range_end:
             req.range_end = range_end.encode("utf-8")
         if rev:


### PR DESCRIPTION
@heidihoward This ensures that we don't service requests that would be expecting linearizability at the moment.